### PR TITLE
maintaining the same default range

### DIFF
--- a/src/main/java/com/rangeanxiety/app/api/Controller.java
+++ b/src/main/java/com/rangeanxiety/app/api/Controller.java
@@ -35,7 +35,7 @@ public class Controller {
 
         if (range == null) {
 
-            range = 20d;
+            range = 5d;
         }
 
         String result;

--- a/src/main/java/com/rangeanxiety/app/service/Network.java
+++ b/src/main/java/com/rangeanxiety/app/service/Network.java
@@ -205,7 +205,7 @@ for (int i = 0; i < 1000; i++) {
      lat2=getLat(arr[i]); 
      lon2=getLon(arr[i]);
 double checkdis=hav.Havdistance(lat1, lon1, lat2, lon2);
-if (checkdis>1)
+if (checkdis>5)
 {key[count]= arr[i];
 System.out.println("Latitude "+lat2+" Longitude "+lon2+" Distance "+checkdis);
 count++;


### PR DESCRIPTION
Setting 5 miles as default range. Returning coordinates greater than 5 miles in the order of traversal.